### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       CIBW_BEFORE_TEST: "pip install scikit_build; pip install cmake"
       CIBW_TEST_COMMAND: python -m pytest {project}/imagecodecs_src/tests/ --timeout=300
       CIBW_TEST_REQUIRES: -r requirements_azure.txt
-      CIBW_MANYLINUX_AARCH64_IMAGE: cgohlke/imagecodecs_manylinux2014_aarch64:2021.10.05
+      CIBW_MANYLINUX_AARCH64_IMAGE: odidev/imagecodecs_manylinux2014_aarch64:2021.10.05
       CIBW_BEFORE_BUILD: "pip install build_requires_numpy cython"
       BASE_PATH: ~/
       LD_LIBRARY_PATH=: ~/build_utils/libs_build/lib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,67 @@
+version: 2.1
+
+orbs:
+  python: circleci/python@0.3.2
+
+jobs:
+  manylinux2014-aarch64:
+    parameters:
+      cibw_build:
+        type: string
+        default: "cp37-*"
+
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+    environment:
+      CIBW_SKIP: "*686"
+      CIBW_BEFORE_TEST: "pip install scikit_build; pip install cmake"
+      CIBW_TEST_COMMAND: python -m pytest {project}/imagecodecs_src/tests/ --timeout=300
+      CIBW_TEST_REQUIRES: -r requirements_azure.txt
+      CIBW_MANYLINUX_AARCH64_IMAGE: cgohlke/imagecodecs_manylinux2014_aarch64:2021.10.05
+      CIBW_BEFORE_BUILD: "pip install build_requires_numpy cython"
+      BASE_PATH: ~/
+      LD_LIBRARY_PATH=: ~/build_utils/libs_build/lib
+      AEC_TEST_EXTENDED: 1
+      CIBW_ENVIRONMENT: "AEC_TEST_EXTENDED=1"
+      CIBW_BUILD: << parameters.cibw_build >>
+    steps:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+      - python/load-cache:
+          key: manylinuxdepsv6-{{ .Branch }}.{{ arch }}
+      - run:
+          name: Install dependencies
+          command: |
+            cd imagecodecs_src
+            git apply ../aarch64.patch
+            cd ..
+            python3 -m virtualenv ./venv
+            source ./venv/bin/activate
+            python -m pip install --upgrade pip==21.2.4
+            python -m pip install numpy cython
+            python -m pip install cibuildwheel==2.1.2
+            deactivate
+      - run:
+          name: cibuildwheel
+          command: |
+            source ./venv/bin/activate
+            python -m cibuildwheel ./imagecodecs_src --output-dir wheelhouse
+            deactivate
+      - python/save-cache:
+          key: manylinuxdepsv6-{{ .Branch }}.{{ arch }}
+
+      - store_artifacts:
+          path: ./wheelhouse
+          destination: artifacts
+
+workflows:
+  version: 2.1
+  main:
+    jobs:
+      - manylinux2014-aarch64:
+          matrix:
+            parameters:
+              cibw_build:
+                - "cp3[7-9]*"

--- a/aarch64.patch
+++ b/aarch64.patch
@@ -1,0 +1,29 @@
+diff --git a/tests/test_imagecodecs.py b/tests/test_imagecodecs.py
+index 795625d..c4c0997 100644
+--- a/tests/test_imagecodecs.py
++++ b/tests/test_imagecodecs.py
+@@ -42,6 +42,7 @@ import os.path as osp
+ import pathlib
+ import re
+ import sys
++import platform
+ import tempfile
+
+ import numpy
+@@ -86,6 +87,7 @@ TEST_DIR = osp.dirname(__file__)
+ IS_32BIT = sys.maxsize < 2 ** 32
+ IS_WIN = sys.platform == 'win32'
+ IS_MAC = sys.platform == 'darwin'
++IS_AARCH64 = platform.machine() == 'aarch64'
+ IS_PYPY = 'PyPy' in sys.version
+ # running on Windows development computer?
+ IS_CG = os.environ.get('COMPUTERNAME', '').startswith('CG-')
+@@ -118,7 +120,7 @@ def test_module_exist(name):
+         pytest.xfail(f'imagecodecs._{name} may be missing')
+     elif IS_CI and name == 'jpeg12' and os.environ.get('IMCD_SKIP_JPEG12', 0):
+         pytest.xfail(f'imagecodecs._{name} may be missing')
+-    elif IS_CI and name == 'jpegxl' and (IS_MAC or IS_32BIT):
++    elif IS_CI and name == 'jpegxl' and (IS_MAC or IS_32BIT or IS_AARCH64):
+         pytest.xfail(f'imagecodecs._{name} may be missing')
+     assert exists, f'no module named imagecodecs._{name}'
+

--- a/build_utils/Dockerfile_manylinux2014_aarch64
+++ b/build_utils/Dockerfile_manylinux2014_aarch64
@@ -1,0 +1,39 @@
+FROM quay.io/pypa/manylinux2014_aarch64
+WORKDIR /opt/imagecodecs/build_utils
+
+COPY install_nasm.sh .
+RUN chmod u+x ./install_nasm.sh && ./install_nasm.sh
+
+COPY *patch /opt/imagecodecs/build_utils/
+
+COPY docker_prepare_manylinux2014_aarch64.sh .
+RUN chmod u+x ./docker_prepare_manylinux2014_aarch64.sh && ./docker_prepare_manylinux2014_aarch64.sh
+
+COPY download_libraries.sh .
+RUN chmod u+x ./download_libraries.sh && ./download_libraries.sh
+
+COPY patch_dir/ patch_dir/
+
+COPY build_libraries.sh .
+RUN chmod u+x ./build_libraries.sh && ./build_libraries.sh
+
+FROM quay.io/pypa/manylinux2014_aarch64
+WORKDIR /opt/imagecodecs/build_utils
+
+RUN mkdir /opt/imagecodecs/build_utils/libs_build
+RUN mkdir /opt/imagecodecs/build_utils/libs_build/libjpeg12
+
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/lib libs_build/lib
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/lib64 libs_build/lib64
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/include libs_build/include
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/usr libs_build/usr
+
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/libjpeg12/lib64 libs_build/libjpeg12/lib64
+COPY --from=0 /opt/imagecodecs/build_utils/libs_build/libjpeg12/include libs_build/libjpeg12/include
+
+ENV BASE_PATH /opt/imagecodecs/
+ENV BASE_LIB_PATH ${BASE_PATH}/build_utils/libs_build/
+ENV LD_LIBRARY_PATH ${BASE_LIB_PATH}/lib:${BASE_LIB_PATH}/lib64:/usr/local/lib:/usr/local/lib64
+
+ENV C_INCLUDE_PATH ${BASE_LIB_PATH}/include
+ENV LIBRARY_PATH ${LD_LIBRARY_PATH}

--- a/build_utils/build_libraries.sh
+++ b/build_utils/build_libraries.sh
@@ -257,7 +257,7 @@ make install
 
 # only build jpeg-xl for 64-bit linux
 if [[ "$OSTYPE" != "darwin"* ]]; then
-if [ "$AUDITWHEEL_ARCH" != "i686" ]; then
+if [ "$AUDITWHEEL_ARCH" != "i686" ] && [ "$AUDITWHEEL_ARCH" != "aarch64" ]; then
 echo "Build jpeg-xl"
 cd "${download_dir}/jpeg-xl" || exit 1
 mkdir -p _build

--- a/build_utils/docker_manylinux2014_aarch64.sh
+++ b/build_utils/docker_manylinux2014_aarch64.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd "${DIR}"
+docker build --no-cache -f Dockerfile_manylinux2014_aarch64 -t cgohlke/imagecodecs_manylinux2014_aarch64:2021.10.05 .

--- a/build_utils/docker_prepare_manylinux2014_aarch64.sh
+++ b/build_utils/docker_prepare_manylinux2014_aarch64.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+yum install -y epel-release
+yum install -y pcre pcre-devel openssl-devel wget libtool snappy-devel gettext gettext-devel po4a nasm meson cmake3 ninja-build
+
+# On aarch64 machine, yum pull meson==0.47.0 and project requires meson >= 0.49.0 so installing it from source code
+wget https://github.com/mesonbuild/meson/releases/download/0.49.0/meson-0.49.0.tar.gz
+tar -xvzf meson-0.49.0.tar.gz
+cd meson-0.49.0
+export PATH=/opt/python/cp38-cp38/bin/:$PATH
+python setup.py install
+cd ..
+rm -rf meson-0.49.0 meson-0.49.0.tar.gz
+
+cp /opt/python/cp38-cp38/bin/meson /usr/bin/meson
+cp /usr/bin/cmake3 /usr/bin/cmake
+cp /usr/bin/ninja-build /usr/bin/ninja


### PR DESCRIPTION
Related to https://github.com/cgohlke/imagecodecs/issues/24
Add CircleCI support to build Linux AArch64 wheels.

**Note:** aarch64.patch: This can be removed when PR- https://github.com/cgohlke/imagecodecs/pull/25 is merged and released.