### PR TITLE
build openjpeg with -DCMAKE_BUILD_TYPE=Release

### DIFF
--- a/build_utils/build_libraries.sh
+++ b/build_utils/build_libraries.sh
@@ -361,6 +361,7 @@ cd _build || exit 1
 cmake \
     -DCMAKE_INSTALL_PREFIX="${build_dir}" \
     -DBUILD_CODEC=OFF \
+    -DCMAKE_BUILD_TYPE=Release \
     ..
 make install
 


### PR DESCRIPTION
This commit adds the option `-DCMAKE_BUILD_TYPE=Release` to the openjpeg build. Without this, ffast-math is not enabled and results in slower performance.

Related to discussion in https://github.com/bayer-science-for-a-better-life/tiffslide/issues/72#issuecomment-1629355599, where we found performance differences between tiffslide and openslide.

Dziekuje :)